### PR TITLE
Fix log focus

### DIFF
--- a/dashboard.jsx
+++ b/dashboard.jsx
@@ -291,7 +291,8 @@ class Dashboard extends Component {
         
         <listbar ref="topMenu"  top={0} items={containerTitles} class={topMenuStyle} />
         {containerOrder.map( key =>
-          <log key={key} hidden={key != activeContainer} ref={'log_' + key} top={1} label="Logs" class={logWindowStyle} />
+          <log key={key} hidden={key != activeContainer} focused={key == activeContainer} 
+            ref={'log_' + key} top={1} label="Logs" class={logWindowStyle} />
         )}
         <listbar ref="bottomMenu" bottom={0} height={1} width="100%-2" left={2} autoCommandKeys={false} commands={{
           'Clear log': {keys:['c']},

--- a/dashboard.jsx
+++ b/dashboard.jsx
@@ -250,6 +250,8 @@ class Dashboard extends Component {
       },
       width: "100%",
       height: "100%-2",
+      keys: true,
+      vi: true,
       mouse: true,
       scrollback: 95,
       scrollbar: {


### PR DESCRIPTION
Currently after focusing the log box the left,right keys and the c,t,a,w,r,h commands become unresponsive, this PR fixes that. Also added vi keys for convenience and autofocusing of the current log for avoiding extra clicks to focus.